### PR TITLE
Fix Example, Add support for CloudWatch-specific credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is actually a plain [Node.js Writable](https://nodejs.org/api/stream.html#s
 
 ``` js
 var bunyan = require('bunyan');
-var createCWStream = require('bunyan-cloudwatch');
+var bunyanCW = require('bunyan-cloudwatch');
 
 var stream = bunyanCW({
   logGroupName: 'my-group',
@@ -35,10 +35,12 @@ With `opts` of:
 - `logGroupName` (required)
 - `logStreamName` (required)
 - `region` (required): the AWS region e.g. `us-west-1`
+- `credentials` (optional): specific CloudWatch credentials to use, otherwise default AWS credentials will be used
 
 On write of the first log, the module creates the logGroup and logStream if necessary.
 
-We use the aws-sdk to write the logs - the AWS credentials have therefore to be configured using environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
+We use the aws-sdk to write the logs - the default AWS credentials have therefore to be configured using environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`). 
+Optionally, you may supply specific credentials to the constructor, if you want to access CloudWatch as different user from the default.
 
 - [Configuring the aws-sdk](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
 - [`CloudWatchLogs.putLogEvents`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatchLogs.html#putLogEvents-property) is the method we use to write logs

--- a/index.js
+++ b/index.js
@@ -46,7 +46,22 @@ CloudWatchStream.prototype._writeLogs = function () {
   var obj = this;
   this.cloudwatch.putLogEvents(log, function (err, res) {
     if (err) {
-      return obj._error(err);
+      
+      log.sequenceToken = err.message.split(": ")[1];
+      if(err.code == "InvalidSequenceTokenException"){
+        obj.cloudwatch.putLogEvents(log, function (err, res) {
+          if (err) {
+              return obj._error(err);
+          }
+          obj.sequenceToken = res.nextSequenceToken;
+          if (obj.queuedLogs.length) {
+            return obj._writeLogs();
+          }
+          obj.writeQueued = false;
+        });
+      }else{
+        return obj._error(err);
+      }
     }
     obj.sequenceToken = res.nextSequenceToken;
     if (obj.queuedLogs.length) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function CloudWatchStream(opts) {
   this.writeInterval = opts.writeInterval || 0;
   AWS.config.update({region: opts.region});
 
-  this.cloudwatch = new AWS.CloudWatchLogs();
+  this.cloudwatch = new AWS.CloudWatchLogs(opts.credentials || null);
   this.queuedLogs = [];
   this.sequenceToken = null;
   this.writeQueued = false;

--- a/index.js
+++ b/index.js
@@ -62,12 +62,13 @@ CloudWatchStream.prototype._writeLogs = function () {
       }else{
         return obj._error(err);
       }
+    }else{
+      obj.sequenceToken = res.nextSequenceToken;
+      if (obj.queuedLogs.length) {
+        return obj._writeLogs();
+      }
+      obj.writeQueued = false;
     }
-    obj.sequenceToken = res.nextSequenceToken;
-    if (obj.queuedLogs.length) {
-      return obj._writeLogs();
-    }
-    obj.writeQueued = false;
   });
 }
 


### PR DESCRIPTION
Allow CloudWatch to use different AWS credentials than the environment
defaults.
Fix README example stream constructor name
Update README to reflect changes
