### PR TITLE
Avoid setting the region globally for the AWS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
+- '4'
+- '5'

--- a/index.js
+++ b/index.js
@@ -15,9 +15,10 @@ function CloudWatchStream(opts) {
   this.logGroupName = opts.logGroupName;
   this.logStreamName = opts.logStreamName;
   this.writeInterval = opts.writeInterval || 0;
-  AWS.config.update({region: opts.region});
 
-  this.cloudwatch = new AWS.CloudWatchLogs();
+  this.cloudwatch = new AWS.CloudWatchLogs({
+    region: opts.region
+  });
   this.queuedLogs = [];
   this.sequenceToken = null;
   this.writeQueued = false;


### PR DESCRIPTION
Using `AWS.config.update({region: opts.region});` to set the region causes it to change for the whole `AWS` module, which is not desirable if other parts of the application are using it.

We can avoid this specifying the region for the `AWS.CloudWatchLogs` instance only.
