### PR TITLE
Fixing InvalidSequenceTokenException on multiple loggers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,12 @@ CloudWatchStream.prototype._writeLogs = function _writeLogs() {
     obj.cloudwatch.putLogEvents(log, function (err, res) {
       if (err) {
         if (err.retryable) return setTimeout(writeLog, obj.writeInterval);
+        if (err.code === 'InvalidSequenceTokenException') {
+          return obj._getSequenceToken((function () {
+            log.sequenceToken = obj.sequenceToken;
+            setTimeout(writeLog, obj.writeInterval);
+          }));
+        }
         return obj._error(err);
       }
       obj.sequenceToken = res.nextSequenceToken;

--- a/index.js
+++ b/index.js
@@ -50,10 +50,10 @@ CloudWatchStream.prototype._writeLogs = function _writeLogs() {
       if (err) {
         if (err.retryable) return setTimeout(writeLog, obj.writeInterval);
         if (err.code === 'InvalidSequenceTokenException') {
-          return obj._getSequenceToken((function () {
+          return obj._getSequenceToken(function () {
             log.sequenceToken = obj.sequenceToken;
             setTimeout(writeLog, obj.writeInterval);
-          }));
+          });
         }
         return obj._error(err);
       }


### PR DESCRIPTION
Addressing open issue: "InvalidSequenceTokenException" thrown when used with multiple instances.

This change will check if the error is of type InvalidSequenceTokenException. If so, it will call _getSequenceToken to update the token and then attempt the call again. 

All tests are passing.