### PR TITLE
Safely load optional dependency safe-json-stringify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+npm-debug.log*

--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@
 var util = require('util');
 var Writable = require('stream').Writable;
 var AWS = require('aws-sdk');
-var safeJsonStringify = require('safe-json-stringify');
+var safeJsonStringify;
+try {
+  safeJsonStringify = require('safe-json-stringify');
+} catch (err) {
+  safeJsonStringify = null;
+}
 
 var jsonStringify = safeJsonStringify ? safeJsonStringify : JSON.stringify;
 


### PR DESCRIPTION
This Pull Request makes the following changes:
- Safely handle loading the optional dependency `safe-json-stringify` with a try/catch so that it does not throw an error if the dependency is not installed
- Add `.gitignore` file

Fixes #29